### PR TITLE
Change width: 500px; to max-width: 500px;

### DIFF
--- a/lib/rack/cerberus.rb
+++ b/lib/rack/cerberus.rb
@@ -150,7 +150,7 @@ module Rack
           }
           div { 
             text-align: left; 
-            width: 500px;
+            max-width: 500px;
             margin: 0px auto; padding: 2em;
             -webkit-border-bottom-left-radius: 3px;
             -moz-border-radius-bottomleft: 3px;


### PR DESCRIPTION
Displays form correctly on screen sizes that have a width of less than 500px.

Example:
Before:
![screen shot 2018-10-01 at 15 08 30](https://user-images.githubusercontent.com/12937166/46310851-8445e080-c58e-11e8-885f-6075c577ee20.png)
After:
![screen shot 2018-10-01 at 15 04 21](https://user-images.githubusercontent.com/12937166/46310888-9c1d6480-c58e-11e8-962e-1bad3eec6bd8.png)
